### PR TITLE
fix(sidebar): 누락된 isSidebarOpen 헬퍼 추가

### DIFF
--- a/src/layout/sideBar/components/MenuItemWithSubmenu.tsx
+++ b/src/layout/sideBar/components/MenuItemWithSubmenu.tsx
@@ -3,14 +3,10 @@ import { ChevronDownIcon } from "@/icons";
 import { MenuItemWithSubmenuProps, MenuType } from "../types";
 import { isSidebarOpen, isSubmenuOpen  } from "../utils/sidebarUtils";
 
-
-
-
 const MenuItemWithSubmenu:React.FC<MenuItemWithSubmenuProps> = ({ nav, index, menuType }) => {
     const { isExpanded, isMobileOpen, isHovered, openSubmenu, toggleSubmenu } = useSidebarStore();
     const showMenu = isSidebarOpen (isExpanded, isHovered, isMobileOpen);
     const showChevronRotated = isSubmenuOpen(openSubmenu, menuType, index);
-
 
     return   <button
               onClick={() => toggleSubmenu(index, menuType)}

--- a/src/layout/sideBar/components/RenderMenuItems.tsx
+++ b/src/layout/sideBar/components/RenderMenuItems.tsx
@@ -4,9 +4,6 @@ import { SidebarMenuProps } from "../types";
 import { useSidebarStore } from "../hooks/useSidebarStore";
 import { isSidebarOpen, isSubmenuOpen  } from "../utils/sidebarUtils";
 
-
-
-
 const RenderMenuItems = ({navItems,
     menuType, subMenuHeight, subMenuRefs, isActive}:SidebarMenuProps) => {
     const { isExpanded, isMobileOpen, isHovered, openSubmenu } = useSidebarStore();

--- a/src/layout/sideBar/components/Section.tsx
+++ b/src/layout/sideBar/components/Section.tsx
@@ -4,9 +4,6 @@ import { SidebarMenuProps, SidebarSectionProps } from "../types";
 import { isSidebarOpen } from "../utils/sidebarUtils";
 import { useSidebarStore } from "@/layout/sideBar/hooks/useSidebarStore";
 
-
-
-
 const Section = ({navItems,menuType,title,subMenuRefs ,subMenuHeight, isActive, handleSubmenuToggle}:SidebarMenuProps&SidebarSectionProps) => {
     const {isExpanded, isHovered, isMobileOpen} = useSidebarStore();
     const showMenu = isSidebarOpen(isExpanded, isHovered, isMobileOpen);

--- a/src/layout/sideBar/components/SidebarWidgetWrapper.tsx
+++ b/src/layout/sideBar/components/SidebarWidgetWrapper.tsx
@@ -1,13 +1,11 @@
+import { isSidebarOpen } from "../utils/sidebarUtils";
 import SidebarWidget from "../widgets/SidebarWidget";
 import { useSidebarStore } from "@/layout/sideBar/hooks/useSidebarStore";
 
-
-
-
-
 const SidebarWidgetWrapper = () => {
     const { isExpanded, isMobileOpen, isHovered} = useSidebarStore();
-    return    (isExpanded || isHovered || isMobileOpen) && <SidebarWidget /> ;
+    const showMenu = isSidebarOpen(isExpanded, isHovered, isMobileOpen);
+    return    (showMenu) && <SidebarWidget /> ;
 }
  
 export default SidebarWidgetWrapper;


### PR DESCRIPTION
- SidebarWidgetWrapper 컴포넌트에서 빠져 있던 사이드바 열림 상태 판단 로직을 isSidebarOpen 헬퍼로 대체 및 추가
- isExpanded || isHovered || isMobileOpen 조건을 util로 통일해 코드 일관성 및 유지보수성 향상