### PR TITLE
리팩터링(sidebar): getSidebarJustifyClass 헬퍼 추가 및 적용

### DIFF
--- a/src/layout/sideBar/components/MenuItemWithSubmenu.tsx
+++ b/src/layout/sideBar/components/MenuItemWithSubmenu.tsx
@@ -1,12 +1,13 @@
 import { useSidebarStore } from "@/layout/sideBar/hooks/useSidebarStore";
 import { ChevronDownIcon } from "@/icons";
 import { MenuItemWithSubmenuProps, MenuType } from "../types";
-import { isSidebarOpen, isSubmenuOpen  } from "../utils/sidebarUtils";
+import { getSidebarJustifyClass, isSidebarOpen, isSubmenuOpen  } from "../utils/sidebarUtils";
 
 const MenuItemWithSubmenu:React.FC<MenuItemWithSubmenuProps> = ({ nav, index, menuType }) => {
     const { isExpanded, isMobileOpen, isHovered, openSubmenu, toggleSubmenu } = useSidebarStore();
     const showMenu = isSidebarOpen (isExpanded, isHovered, isMobileOpen);
     const showChevronRotated = isSubmenuOpen(openSubmenu, menuType, index);
+    
 
     return   <button
               onClick={() => toggleSubmenu(index, menuType)}
@@ -15,7 +16,7 @@ const MenuItemWithSubmenu:React.FC<MenuItemWithSubmenuProps> = ({ nav, index, me
                   ? "menu-item-active"
                   : "menu-item-inactive"
               } cursor-pointer ${
-                !isExpanded && !isHovered
+                !isExpanded && !isHovered 
                   ? "lg:justify-center"
                   : "lg:justify-start"
               }`}

--- a/src/layout/sideBar/components/Section.tsx
+++ b/src/layout/sideBar/components/Section.tsx
@@ -1,20 +1,18 @@
 import { HorizontaLDots } from "@/icons";
 import RenderMenuItems from "./RenderMenuItems";
 import { SidebarMenuProps, SidebarSectionProps } from "../types";
-import { isSidebarOpen } from "../utils/sidebarUtils";
+import { getSidebarJustifyClass, isSidebarOpen } from "../utils/sidebarUtils";
 import { useSidebarStore } from "@/layout/sideBar/hooks/useSidebarStore";
 
 const Section = ({navItems,menuType,title,subMenuRefs ,subMenuHeight, isActive, handleSubmenuToggle}:SidebarMenuProps&SidebarSectionProps) => {
     const {isExpanded, isHovered, isMobileOpen} = useSidebarStore();
     const showMenu = isSidebarOpen(isExpanded, isHovered, isMobileOpen);
+     const justifyClass = getSidebarJustifyClass(isExpanded, isHovered);
+
 
     return (<div>
               <h2
-                className={`mb-4 text-xs uppercase flex leading-[20px] text-gray-400 ${
-                  !isExpanded && !isHovered
-                    ? "lg:justify-center"
-                    : "justify-start"
-                }`}
+                className={`mb-4 text-xs uppercase flex leading-[20px] text-gray-400 ${ justifyClass }`}
               >
                 {showMenu ?
                   title: (

--- a/src/layout/sideBar/components/SidebarLogo.tsx
+++ b/src/layout/sideBar/components/SidebarLogo.tsx
@@ -1,17 +1,17 @@
 import { useSidebarStore } from "@/layout/sideBar/hooks/useSidebarStore";
 import Image from "next/image";
 import Link from "next/link";
-import { isSidebarOpen } from "../utils/sidebarUtils";
+import { getSidebarJustifyClass, isSidebarOpen } from "../utils/sidebarUtils";
 
 
 const SidebarLogo = () => {
     const { isExpanded, isMobileOpen, isHovered } = useSidebarStore();
     const showMenu = isSidebarOpen(isExpanded, isHovered, isMobileOpen);
+    const justifyClass = getSidebarJustifyClass(isExpanded, isHovered);
+
 
     return <div
-        className={`py-8 flex  ${
-          !isExpanded && !isHovered ? "lg:justify-center" : "justify-start"
-        }`}
+        className={`py-8 flex  ${justifyClass}`}
       >
         <Link href="/">
           {showMenu ? (

--- a/src/layout/sideBar/utils/sidebarUtils.ts
+++ b/src/layout/sideBar/utils/sidebarUtils.ts
@@ -11,3 +11,12 @@ export const isSubmenuOpen = (
 ): boolean => {
   return openSubmenu?.type === menuType && openSubmenu?.index === index;
 };
+
+export function getSidebarJustifyClass(
+  isExpanded: boolean,
+  isHovered: boolean
+): string {
+  return !isExpanded && !isHovered
+    ? "lg:justify-center"
+    : "justify-start";
+}


### PR DESCRIPTION
- sideBar/utils/sidebarUtils.ts에 getSidebarJustifyClass 함수 추가
- Section 컴포넌트 등에서 반복되던 정렬용 삼항 연산(get lg:justify-center/justify-start) → 헬퍼 호출로 대체
- 코드 중복 제거 및 가독성·유지보수성 향상